### PR TITLE
Fix Auto Bookmarker for ChroMapper 0.8.0

### DIFF
--- a/ChroMapperAutoBookmarker/ChroMapperAutoBookmarker.csproj
+++ b/ChroMapperAutoBookmarker/ChroMapperAutoBookmarker.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ChroMapperAutoBookmarker</RootNamespace>
     <AssemblyName>ChroMapperAutoBookmarker</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,6 +34,9 @@
   <ItemGroup>
     <Reference Include="Main">
       <HintPath>$(ChroMapperDir)\ChroMapper_Data\Managed\Main.dll</HintPath>
+    </Reference>
+    <Reference Include="Input">
+      <HintPath>$(ChroMapperDir)\ChroMapper_Data\Managed\Input.dll</HintPath>
     </Reference>
     <Reference Include="Plugins">
       <HintPath>$(ChroMapperDir)\ChroMapper_Data\Managed\Plugins.dll</HintPath>

--- a/ChroMapperAutoBookmarker/PromptManager.cs
+++ b/ChroMapperAutoBookmarker/PromptManager.cs
@@ -96,7 +96,7 @@ namespace ChroMapperAutoBookmarker
                 case GENERATE_STATE:
                     BookmarkManager bookmarkManager = Resources.FindObjectsOfTypeAll<BookmarkManager>().First();
                     AudioTimeSyncController atsc = Resources.FindObjectsOfTypeAll<AudioTimeSyncController>().First();
-                    float lastBeat = atsc.GetBeatFromSeconds(atsc.songAudioSource.clip.length);
+                    float lastBeat = atsc.GetBeatFromSeconds(atsc.SongAudioSource.clip.length);
 
                     float currentBeat = StartBeat;
                     int count = 1;
@@ -105,7 +105,7 @@ namespace ChroMapperAutoBookmarker
                     {
                         BeatmapBookmark newBookmark = new BeatmapBookmark(currentBeat, string.IsNullOrWhiteSpace(Name) ? $"{count}" : $"{Name} {count}");
                         BookmarkContainer container = MonoBehaviour.Instantiate(bookmarkManager.GetField<GameObject>("bookmarkContainerPrefab"), bookmarkManager.transform).GetComponent<BookmarkContainer>();
-                        container.name = newBookmark._name;
+                        container.name = newBookmark.Name;
                         container.Init(bookmarkManager, newBookmark);
                         container.RefreshPosition(bookmarkManager.GetField<RectTransform>("timelineCanvas").sizeDelta.x + bookmarkManager.GetField<float>("CANVAS_WIDTH_OFFSET"));
                         bookmarkManager.GetField<List<BookmarkContainer>>("bookmarkContainers").Add(container);
@@ -114,7 +114,7 @@ namespace ChroMapperAutoBookmarker
                             amountLeft--;
                         count++;
                     }
-                    BeatSaberSongContainer.Instance.map._bookmarks = bookmarkManager.GetField<List<BookmarkContainer>>("bookmarkContainers").Select(x => x.data).ToList();
+                    BeatSaberSongContainer.Instance.Map.Bookmarks = bookmarkManager.GetField<List<BookmarkContainer>>("bookmarkContainers").Select(x => x.Data).ToList();
                     Utils.SetActionMapsEnabled(true);
                     break;
             }


### PR DESCRIPTION
This PR introduces fixes to allow the plugin to compile for ChroMapper 0.8.0

More specifically, ChroMapper underwent a project refactor to enforce coding guidelines and styling, which requires plugins to be rebuilt and fixed.

I have also bumped this project to target .NET Framework 4.8 due to the newer version of Harmony that comes bundled with ChroMapper.